### PR TITLE
Add VideoCard component and sample data rendering

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,17 +1,15 @@
 <script setup lang="ts">
-import HelloWorld from './components/HelloWorld.vue'
+import { sampleVideos } from './assets/sample.js';
+import VideoCard from './components/VideoCard.vue';
 </script>
 
 <template>
-  <div>
-    <a href="https://vite.dev" target="_blank">
-      <img src="/vite.svg" class="logo" alt="Vite logo" />
-    </a>
-    <a href="https://vuejs.org/" target="_blank">
-      <img src="./assets/vue.svg" class="logo vue" alt="Vue logo" />
-    </a>
+  <div class="p-6">
+    <h1 class="text-2xl font-bold mb-6">Sample Videos</h1>
+    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+      <VideoCard v-for="video in sampleVideos" :key="video.videoId" :video="video" />
+    </div>
   </div>
-  <HelloWorld msg="Vite + Vue" />
 </template>
 
 <style scoped>

--- a/src/assets/sample.js
+++ b/src/assets/sample.js
@@ -1,0 +1,30 @@
+export const sampleVideos = [
+    {
+      videoId: "abc123",
+      title: "MIT Lecture 1: Introduction to Computer Science",
+      channelTitle: "MIT OpenCourseWare",
+      publishedAt: "2022-01-15T12:00:00Z",
+      thumbnail: {
+        url: "https://i.ytimg.com/vi/abc123/hqdefault.jpg"
+      }
+    },
+    {
+      videoId: "def456",
+      title: "MIT Lecture 2: Data Structures",
+      channelTitle: "MIT OpenCourseWare",
+      publishedAt: "2022-01-22T12:00:00Z",
+      thumbnail: {
+        url: "https://i.ytimg.com/vi/def456/hqdefault.jpg"
+      }
+    },
+    {
+      videoId: "ghi789",
+      title: "MIT Lecture 3: Algorithms and Complexity",
+      channelTitle: "MIT OpenCourseWare",
+      publishedAt: "2022-01-29T12:00:00Z",
+      thumbnail: {
+        url: "https://i.ytimg.com/vi/ghi789/hqdefault.jpg"
+      }
+    }
+  ];
+  

--- a/src/components/VideoCard.vue
+++ b/src/components/VideoCard.vue
@@ -1,0 +1,28 @@
+<template>
+    <div class="border rounded-lg shadow-md p-4 hover:shadow-lg transition">
+      <img :src="video.thumbnail.url" :alt="video.title" class="w-full h-auto mb-4 rounded" />
+      <h2 class="text-lg font-semibold">{{ video.title }}</h2>
+      <p class="text-sm text-gray-600">{{ video.channelTitle }}</p>
+      <p class="text-xs text-gray-500">{{ formattedDate }}</p>
+    </div>
+  </template>
+  
+  <script setup lang="ts">
+  import { computed } from 'vue';
+  
+  const props = defineProps<{
+    video: {
+      videoId: string;
+      title: string;
+      channelTitle: string;
+      publishedAt: string;
+      thumbnail: {
+        url: string;
+      };
+    };
+  }>();
+  
+  const formattedDate = computed(() => {
+    return new Date(props.video.publishedAt).toLocaleDateString();
+  });
+  </script>


### PR DESCRIPTION
### Summary
This merge request introduces the `VideoCard.vue` component and integrates it into `App.vue` for initial testing. Dummy video data is used to validate component layout and rendering logic.

### Changes
- Created reusable `VideoCard` component with props.
- Set up local sample video data (`sample.js`).
- Rendered a list of sample videos in `App.vue`.

### Next Steps
- Implement responsive layout and grid styling for video cards.
- Wire up real data from backend (GraphQL) once available.
- Later: move video list logic into a container component.